### PR TITLE
bug(movies): fix incorrect output path for compressed movies in loop

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -224,7 +224,7 @@ def process_series(input_dir, output_dir):
 
 
 # Process movies
-def process_movies(input_dir, output_dir):
+def process_movies(input_dir, output_dir_base):
     for dirpath, dirnames, _ in os.walk(input_dir):
         for movie_dir in dirnames:
             movie_path = os.path.join(dirpath, movie_dir)
@@ -238,7 +238,7 @@ def process_movies(input_dir, output_dir):
                 continue
 
             input_file = os.path.join(movie_path, movie_file)
-            output_dir = os.path.join(output_dir, movie_name)
+            output_dir = os.path.join(output_dir_base, movie_name)
             output_file = os.path.join(output_dir, f"{movie_name}.mkv")
 
             os.makedirs(output_dir, exist_ok=True)


### PR DESCRIPTION
The issue where subsequent movies were saved inside the folder of the previous compressed movie has been resolved. The output path is now correctly set to the root destination folder for each movie compression iteration.

## Description

Fixes #12 

## Type of change

Please mark the relevant options:

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Improvement
- [ ] Performance optimization
- [ ] Refactor update
- [ ] Documentation update
- [ ] Security fix
- [ ] Test update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](../blob/main/CONTRIBUTING.md) guidelines
- [x] The code follows the project's coding standards and best practices (see [**STYLEGUIDE**](../blob/main/docs/styleguide.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the [**README**](../blob/main/README.md) or documentation, if necessary
- [x] I have added relevant tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass with my changes
- [x] Any dependent changes have been merged and published in downstream modules