### PR TITLE
bug(shared folder): fix utf8 characters of shared folders

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -1,8 +1,8 @@
 SMB_USERNAME="" # Username for the SMB share
 SMB_PASSWORD="" # Password for the SMB share
 SMB_INPUT_SERIES="" # Path to the input series folder on the samba share
-SMB_OUTPUT_SERIES="" # Path to the output series folder on the samba share
 SMB_INPUT_MOVIES="" # Path to the input movies folder on the samba share
+SMB_OUTPUT_SERIES="" # Path to the output series folder on the samba share
 SMB_OUTPUT_MOVIES="" # Path to the output movies folder on the samba share
 CRF="" # Constant Rate Factor (CRF) for the x264 encoder (0-51)
 PRESET="" # Preset for the x264 encoder (ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow)

--- a/src/main.py
+++ b/src/main.py
@@ -35,8 +35,8 @@ def signal_handler(sig, frame):
     sys.exit(0)
 
 
-# Mount SMB folder as read-only
-def mount_smb_readonly(smb_path, username, password, read_only=True):
+# Mount SMB folder
+def mount_smb(smb_path, username, password, read_only=True):
     temp_dir = tempfile.mkdtemp()  # Create a temporary directory
     # Create a temporary credentials file
     credentials_file = tempfile.mktemp(suffix='.credentials')
@@ -50,12 +50,12 @@ def mount_smb_readonly(smb_path, username, password, read_only=True):
     if read_only:
         mount_cmd = (
             f"mount -t cifs {shlex.quote(smb_path)} {shlex.quote(temp_dir)} "
-            f"-o credentials={shlex.quote(credentials_file)},ro"
+            f"-o credentials={shlex.quote(credentials_file)},iocharset=utf8,ro"
         )
     else:
         mount_cmd = (
             f"mount -t cifs {shlex.quote(smb_path)} {shlex.quote(temp_dir)} "
-            f"-o credentials={shlex.quote(credentials_file)}"
+            f"-o credentials={shlex.quote(credentials_file)},iocharset=utf8"
         )
 
     try:
@@ -374,10 +374,10 @@ def main():
 
         if args.type == "series":
             print("Processing series...")
-            input_dir = mount_smb_readonly(
+            input_dir = mount_smb(
                 SMB_INPUT_SERIES, SMB_USERNAME, SMB_PASSWORD, True
             )
-            output_dir = mount_smb_readonly(
+            output_dir = mount_smb(
                 SMB_OUTPUT_SERIES, SMB_USERNAME, SMB_PASSWORD, False
             )
             if input_dir and output_dir:
@@ -388,10 +388,10 @@ def main():
                 unmount_and_cleanup(output_dir)
         elif args.type == "movies":
             print("Processing movies...")
-            input_dir = mount_smb_readonly(
+            input_dir = mount_smb(
                 SMB_INPUT_MOVIES, SMB_USERNAME, SMB_PASSWORD, True
             )
-            output_dir = mount_smb_readonly(
+            output_dir = mount_smb(
                 SMB_OUTPUT_MOVIES, SMB_USERNAME, SMB_PASSWORD, False
             )
             if input_dir and output_dir:


### PR DESCRIPTION
## Description

If a shared folder contains non-UTF8 characters, it is not mounted.

## Type of change

Please mark the relevant options:

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Improvement
- [x] Performance optimization
- [x] Refactor update
- [x] Documentation update
- [x] Security fix
- [x] Test update
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please describe):

## Checklist

- [ ] I have read the [**CONTRIBUTING**](../blob/main/CONTRIBUTING.md) guidelines
- [ ] The code follows the project's coding standards and best practices (see [**STYLEGUIDE**](../blob/main/docs/styleguide.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the [**README**](../blob/main/README.md) or documentation, if necessary
- [ ] I have added relevant tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules